### PR TITLE
Fix period-based reverts, add balances to header

### DIFF
--- a/src/district_hegex/shared/smart_contracts_dev.cljs
+++ b/src/district_hegex/shared/smart_contracts_dev.cljs
@@ -11,5 +11,7 @@
                  :address "0x3961245DB602eD7c03eECcda33eA3846bD8723BD"}
    :hegicethoptions {:name "HegicETHOptions"
                      :address "0xEfC0eEAdC1132A12c9487d800112693bf49EcfA2"}
+   :wbtc {:name "FakeWBTC"
+          :address "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"}
    :hegicercpool {:name "HegicERCPool" :address "0x20DD9e22d22dd0a6ef74a520cb08303B5faD5dE7"}
    :hegicethpool {:name "HegicETHPool" :address "0x878F15ffC8b894A1BA7647c7176E4C01f74e140b"}})

--- a/src/district_hegex/shared/smart_contracts_prod.cljs
+++ b/src/district_hegex/shared/smart_contracts_prod.cljs
@@ -9,6 +9,8 @@
    ;; NOTE external contracts down below
    :weth {:name "WETH"
           :address "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"}
+   :wbtc {:name "FakeWBTC"
+          :address "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"}
    :wbtcoptions {:name "HegicWBTCOptions"
                  :address "0x3961245DB602eD7c03eECcda33eA3846bD8723BD"}
    :brokenethoptions {:name "BrokenETHOptions"

--- a/src/district_hegex/ui/contract/hegex_nft.cljs
+++ b/src/district_hegex/ui/contract/hegex_nft.cljs
@@ -549,7 +549,7 @@
                  {:instance (contract-queries/instance db :optionchef)
                   :fn :createHegic
                   :args opt-args
-                  :tx-opts {:value (some->> fees extract-fee bn/number)
+                  :tx-opts {:value (some->> fees extract-fee)
                             :from (account-queries/active-account db)}
                   :tx-id :mint-hegex!
                   :on-tx-success [::mint-hegex-success]

--- a/src/district_hegex/ui/core.cljs
+++ b/src/district_hegex/ui/core.cljs
@@ -84,7 +84,8 @@
                       config/config-map
                       {:smart-contracts {:request-timeout 120000
                                          :format :truffle-json}
-                       ;; :web3-account-balances {:for-contracts [:ETH :DNT]}
+                       :web3-balances {:contracts {:WBTC {:address "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599"}}}
+                       :web3-account-balances {:for-contracts [:ETH :WBTC]}
                        :web3-tx-log {:tx-costs-currencies [:USD]
                                      :default-settings {:from-active-address-only? true}}
                        :reagent-render {:id "app"

--- a/src/district_hegex/ui/home/orderbook.cljs
+++ b/src/district_hegex/ui/home/orderbook.cljs
@@ -347,6 +347,11 @@
 (defn controls []
   (let [active-option @(subscribe [::home-subs/my-orderbook-option])
         weth-bal @(subscribe [::weth-subs/balance])
+        wbtc-bal (some-> (subscribe
+                          [::account-balances-subs/active-account-balance :WBTC])
+                         deref
+                         (/ (js/Math.pow 10 8))
+                         (format/format-number {:max-fraction-digits 5}))
         eth-bal (some-> (subscribe
                           [::account-balances-subs/active-account-balance :ETH])
                          deref

--- a/src/district_hegex/ui/home/page.cljs
+++ b/src/district_hegex/ui/home/page.cljs
@@ -607,8 +607,13 @@
 
 (defn- current-prices [btc-price eth-price]
   [:div.current-prices
-   [:p.small "Bitcoin: " [:b (str "$" btc-price)]]
-   [:p.small "Ethereum: " [:b (str "$" eth-price) ]]])
+   [:p.small "Ethereum: " [:b (str "$" eth-price) ]]
+   [:p.small "Bitcoin: " [:b (str "$" btc-price)]]])
+
+(defn- current-balances [wbtc-bal eth-bal]
+  [:div.current-prices {:style {:text-align "left"}}
+   [:p.small "ETH Balance: " [:b eth-bal ]]
+   [:p.small "WBTC Balance: " [:b wbtc-bal]]])
 
 (defn- my-hegic-options []
   (let [opts (subscribe [::subs/hegic-full-options])
@@ -617,10 +622,23 @@
         resetter (fn [v]
                    (println "sorted options are" v)
                    (dispatch [::events/set-hegic-ui-options v]))
+        wbtc-bal (some-> (subscribe
+                          [::account-balances-subs/active-account-balance :WBTC])
+                         deref
+                         (/ (js/Math.pow 10 8))
+                         (format/format-number {:max-fraction-digits 5}))
+        eth-bal (some-> (subscribe
+                          [::account-balances-subs/active-account-balance :ETH])
+                         deref
+                         web3-utils/wei->eth-number
+                         (format/format-number {:max-fraction-digits 5}))
         #_init-loaded? #_(subscribe [::tx-id-subs/tx-pending? :get-balance])]
     [:div
      (when (and btc-price eth-price)
-       [current-prices btc-price eth-price])
+       [:div {:style {:display "flex"
+                      :justify-content "space-between"}}
+        [current-balances wbtc-bal eth-bal]
+        [current-prices btc-price eth-price]])
      [:div {:style {:display "flex"
                     :align-items "flex-start"
                     :justify-content "flex-start"}}


### PR DESCRIPTION
- Adding balances via district0x/district-ui-web3-account-balances: WBTC+ETH
- Fixed important issue with intermittent revert on various option period param;  was caused by JS number truncating, fixed by transporting number via BN instead of plain JS number (BN is used in other places as well, this one was a miss)

Moved selects to other branch, merging important fix in this branch